### PR TITLE
introduced crude hotfix re android6 permissions schema

### DIFF
--- a/assignments/assignment4b/app/src/main/java/vandy/mooc/presenter/ImagePresenter.java
+++ b/assignments/assignment4b/app/src/main/java/vandy/mooc/presenter/ImagePresenter.java
@@ -11,6 +11,8 @@ import vandy.mooc.common.GenericPresenter;
 import vandy.mooc.common.Utils;
 import vandy.mooc.model.ImageModel;
 import vandy.mooc.model.datamodel.ReplyMessage;
+import vandy.mooc.utils.GetPermissions;
+
 import android.app.Activity;
 import android.content.Context;
 import android.net.Uri;
@@ -105,6 +107,9 @@ public class ImagePresenter
         // instance.
         super.onCreate(ImageModel.class,
                        this);
+
+        // added this because I suspect permissions problems
+        GetPermissions.requestPermissions(this.getActivityContext());
     }
 
     /**

--- a/assignments/assignment4b/app/src/main/java/vandy/mooc/utils/GetPermissions.java
+++ b/assignments/assignment4b/app/src/main/java/vandy/mooc/utils/GetPermissions.java
@@ -1,0 +1,72 @@
+package vandy.mooc.utils;
+
+import android.Manifest;
+import android.app.Activity;
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.support.v4.app.ActivityCompat;
+import android.support.v4.content.ContextCompat;
+import android.util.Log;
+import android.widget.Toast;
+
+/**
+ * Created by Samuel Lijin on 4/20/2016.
+ *
+ * Code derived from answer at http://stackoverflow.com/a/33164852/3577414.
+ */
+public class GetPermissions {
+    private static final int REQUEST_WRITE_STORAGE = 112;
+    private static boolean hasPermission;
+
+    public static void requestPermissions(Context activity) {
+        if (hasPermission) return;
+        
+        Log.d("GetPermissions", "requesting permissions");
+        // check if write_external_storage permissions have been granted
+        hasPermission = (
+                ContextCompat.checkSelfPermission(activity,
+                                                  Manifest
+                                                      .permission
+                                                      .WRITE_EXTERNAL_STORAGE
+                ) == PackageManager.PERMISSION_GRANTED
+        );
+
+        Activity parentActivity = (Activity) activity;
+
+        // request permissions if they have not been granted
+        if (!hasPermission) {
+            ActivityCompat.requestPermissions(
+                    parentActivity,
+                    new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE},
+                    REQUEST_WRITE_STORAGE
+            );
+        }
+
+    }
+
+    // some callback - currently unused
+    public static void onRequestPermissionsResult(Context parentActivity,
+                                                  int requestCode,
+                                                  String[] permissions,
+                                                  int[] grantResults) {
+        switch (requestCode)
+        {
+            case REQUEST_WRITE_STORAGE: {
+                if (grantResults.length > 0 && grantResults[0]
+                        == PackageManager.PERMISSION_GRANTED)
+                {
+                    //reload my activity with permission granted or use
+                    // the features what required the permission
+                }
+                else
+                {
+                    Toast.makeText(parentActivity, "The app was not allowed " +
+                            "to write to your storage. Hence, it cannot " +
+                            "function properly. Please consider granting it " +
+                            "this permission", Toast.LENGTH_LONG).show();
+                }
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
Due to what seems to be a particular quirk specific to Android 6.0's permissions model, I discovered that I was seeing a number of WRITE_EXTERNAL_STORAGE and READ_EXTERNAL_STORAGE errors in the logcat (no, I did not modify AndroidManifest.xml). 

For whatever reason, 4b was not prompting me to allow it to read from and write to external storage, even after wiping the emulator, so I searched StackOverflow for guidance regarding how to resolve such permissions errors, and came up with a somewhat crude fix to resolve the permissions issue. (On a side note, NetUtils.isExternalStorageWritable() also definitely does not behave as it should, because it was not catching this error.)

I've posted on Coursera about this [here](https://www.coursera.org/learn/cs251-003/discussions/ooe6Hwd5EeaGrhI0SW4tcQ).